### PR TITLE
fix: update GraphQL schema definitions and improve type safety

### DIFF
--- a/playground/server/graphql/schema.ts
+++ b/playground/server/graphql/schema.ts
@@ -1,16 +1,10 @@
-import { z } from 'zod'
+// import { z } from 'zod'
 
 export default defineSchema({
-  Todo: z.object({
-    id: z.string(),
-    title: z.string(),
-    completed: z.boolean(),
-    createdAt: z.date(),
-  }),
-  User: z.object({
-    id: z.string(),
-    name: z.string(),
-    email: z.string().email(),
-    age: z.number().min(0),
-  }),
+  // User: z.object({
+  //   id: z.string(),
+  //   name: z.string(),
+  //   email: z.string().email(),
+  //   age: z.number().min(0),
+  // }),
 })

--- a/src/utils/define.ts
+++ b/src/utils/define.ts
@@ -1,8 +1,8 @@
-import type { Resolvers, ResolversTypes, StandardSchemaV1 } from '#graphql/server'
+import type { Resolvers, ResolversTypes } from '#graphql/server'
 import type { ApolloServerOptions, BaseContext } from '@apollo/server'
 import type { YogaServerOptions } from 'graphql-yoga'
 
-import type { GraphQLFramework } from 'nitro-graphql'
+import type { GraphQLFramework, StandardSchemaV1 } from 'nitro-graphql'
 
 type Flatten<T> = T extends infer U ? { [K in keyof U]: U[K] } : never
 

--- a/src/utils/server-codegen.ts
+++ b/src/utils/server-codegen.ts
@@ -85,7 +85,18 @@ export async function generateTypes(
 
               `
 export type SchemaType = Partial<Record<Partial<keyof ResolversTypes>, StandardSchemaV1>>
-type SchemaKeys = keyof typeof schemas;
+
+// Check if schemas is empty object, return never if so
+type SafeSchemaKeys<T> = T extends Record<PropertyKey, never> 
+  ? never 
+  : keyof T extends string | number | symbol
+    ? keyof T extends never 
+      ? never 
+      : keyof T
+    : never;
+    
+
+type SchemaKeys = SafeSchemaKeys<typeof schemas>;
 
 type InferInput<T> = T extends StandardSchemaV1 ? StandardSchemaV1.InferInput<T> : unknown;
 type InferOutput<T> = T extends StandardSchemaV1 ? StandardSchemaV1.InferOutput<T> : unknown;


### PR DESCRIPTION
If schema.ts does not exist, the system cannot find the types. This contains the fix.