### PR TITLE
fix: update type imports for ApolloServerOptions and YogaServerOption

### DIFF
--- a/src/utils/define.ts
+++ b/src/utils/define.ts
@@ -1,6 +1,7 @@
 import type { Resolvers, ResolversTypes } from '#graphql/server'
-import type { ApolloServerOptions, BaseContext } from '@apollo/server'
+import type { ApolloServerOptions } from '@apollo/server'
 import type { YogaServerOptions } from 'graphql-yoga'
+import type { H3Event } from 'h3'
 
 import type { GraphQLFramework, StandardSchemaV1 } from 'nitro-graphql'
 
@@ -60,9 +61,9 @@ export function defineType(
 }
 
 export type DefineServerConfig = GraphQLFramework extends 'graphql-yoga'
-  ? Partial<YogaServerOptions<any, any>>
+  ? Partial<YogaServerOptions<H3Event, H3Event>>
   : GraphQLFramework extends 'apollo-server'
-    ? Partial<ApolloServerOptions<BaseContext>>
+    ? Partial<ApolloServerOptions<H3Event>>
     : Record<string, any>
 
 export function defineGraphQLConfig(


### PR DESCRIPTION
context types were not coming here. Now it can be accessed from anywhere.
<img width="1758" height="1002" alt="CleanShot 2025-07-17 at 12 59 04@2x" src="https://github.com/user-attachments/assets/7b48303d-3594-4197-9b29-3b3309c65447" />
