### PR TITLE
feat: enhance GraphQL SDK with execution result types and code 

### DIFF
--- a/playground-nuxt/app/graphql/sdk.ts
+++ b/playground-nuxt/app/graphql/sdk.ts
@@ -5,6 +5,7 @@
 /* prettier-ignore */
 import type * as Types from '#graphql/client';
 
+import type { ExecutionResult } from 'graphql';
 
 export const CreateUserDocument = /*#__PURE__*/ `
     mutation CreateUser($input: CreateUserInput!) {
@@ -51,23 +52,23 @@ export const GetUserDocument = /*#__PURE__*/ `
   }
 }
     `;
-export type Requester<C = {}> = <R, V>(doc: string, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
-export function getSdk<C>(requester: Requester<C>) {
+export type Requester<C = {}, E = unknown> = <R, V>(doc: string, vars?: V, options?: C) => Promise<ExecutionResult<R, E>> | AsyncIterable<ExecutionResult<R, E>>
+export function getSdk<C, E>(requester: Requester<C, E>) {
   return {
-    CreateUser(variables: Types.CreateUserMutationVariables, options?: C): Promise<Types.CreateUserMutation> {
-      return requester<Types.CreateUserMutation, Types.CreateUserMutationVariables>(CreateUserDocument, variables, options) as Promise<Types.CreateUserMutation>;
+    CreateUser(variables: Types.CreateUserMutationVariables, options?: C): Promise<ExecutionResult<Types.CreateUserMutation, E>> {
+      return requester<Types.CreateUserMutation, Types.CreateUserMutationVariables>(CreateUserDocument, variables, options) as Promise<ExecutionResult<Types.CreateUserMutation, E>>;
     },
-    UpdateUser(variables: Types.UpdateUserMutationVariables, options?: C): Promise<Types.UpdateUserMutation> {
-      return requester<Types.UpdateUserMutation, Types.UpdateUserMutationVariables>(UpdateUserDocument, variables, options) as Promise<Types.UpdateUserMutation>;
+    UpdateUser(variables: Types.UpdateUserMutationVariables, options?: C): Promise<ExecutionResult<Types.UpdateUserMutation, E>> {
+      return requester<Types.UpdateUserMutation, Types.UpdateUserMutationVariables>(UpdateUserDocument, variables, options) as Promise<ExecutionResult<Types.UpdateUserMutation, E>>;
     },
-    DeleteUser(variables: Types.DeleteUserMutationVariables, options?: C): Promise<Types.DeleteUserMutation> {
-      return requester<Types.DeleteUserMutation, Types.DeleteUserMutationVariables>(DeleteUserDocument, variables, options) as Promise<Types.DeleteUserMutation>;
+    DeleteUser(variables: Types.DeleteUserMutationVariables, options?: C): Promise<ExecutionResult<Types.DeleteUserMutation, E>> {
+      return requester<Types.DeleteUserMutation, Types.DeleteUserMutationVariables>(DeleteUserDocument, variables, options) as Promise<ExecutionResult<Types.DeleteUserMutation, E>>;
     },
-    GetUsers(variables?: Types.GetUsersQueryVariables, options?: C): Promise<Types.GetUsersQuery> {
-      return requester<Types.GetUsersQuery, Types.GetUsersQueryVariables>(GetUsersDocument, variables, options) as Promise<Types.GetUsersQuery>;
+    GetUsers(variables?: Types.GetUsersQueryVariables, options?: C): Promise<ExecutionResult<Types.GetUsersQuery, E>> {
+      return requester<Types.GetUsersQuery, Types.GetUsersQueryVariables>(GetUsersDocument, variables, options) as Promise<ExecutionResult<Types.GetUsersQuery, E>>;
     },
-    GetUser(variables: Types.GetUserQueryVariables, options?: C): Promise<Types.GetUserQuery> {
-      return requester<Types.GetUserQuery, Types.GetUserQueryVariables>(GetUserDocument, variables, options) as Promise<Types.GetUserQuery>;
+    GetUser(variables: Types.GetUserQueryVariables, options?: C): Promise<ExecutionResult<Types.GetUserQuery, E>> {
+      return requester<Types.GetUserQuery, Types.GetUserQueryVariables>(GetUserDocument, variables, options) as Promise<ExecutionResult<Types.GetUserQuery, E>>;
     }
   };
 }

--- a/playground/graphql/sdk.ts
+++ b/playground/graphql/sdk.ts
@@ -5,22 +5,18 @@
 /* prettier-ignore */
 import type * as Types from '#graphql/client';
 
-export type GetUsersQueryVariables = Types.Exact<{ [key: string]: never; }>;
-
-
-export type GetUsersQuery = { __typename?: 'Query', hello: string };
-
+import type { ExecutionResult } from 'graphql';
 
 export const GetUsersDocument = /*#__PURE__*/ `
     query GetUsers {
   hello
 }
     `;
-export type Requester<C = {}> = <R, V>(doc: string, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
-export function getSdk<C>(requester: Requester<C>) {
+export type Requester<C = {}, E = unknown> = <R, V>(doc: string, vars?: V, options?: C) => Promise<ExecutionResult<R, E>> | AsyncIterable<ExecutionResult<R, E>>
+export function getSdk<C, E>(requester: Requester<C, E>) {
   return {
-    GetUsers(variables?: Types.GetUsersQueryVariables, options?: C): Promise<Types.GetUsersQuery> {
-      return requester<Types.GetUsersQuery, Types.GetUsersQueryVariables>(GetUsersDocument, variables, options) as Promise<Types.GetUsersQuery>;
+    GetUsers(variables?: Types.GetUsersQueryVariables, options?: C): Promise<ExecutionResult<Types.GetUsersQuery, E>> {
+      return requester<Types.GetUsersQuery, Types.GetUsersQueryVariables>(GetUsersDocument, variables, options) as Promise<ExecutionResult<Types.GetUsersQuery, E>>;
     }
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,13 @@ export type { StandardSchemaV1 } from './standard-schema'
 export type CodegenServerConfig = TypeScriptPluginConfig & TypeScriptResolversPluginConfig
 
 // CODEGEN
-export type GenericSdkConfig = Parameters<typeof typescriptGenericSdk>[2]
+type DocumentModeConfig = Pick<Parameters<typeof typescriptGenericSdk>[2], 'documentMode'>
+type DocumentModeEnum = NonNullable<DocumentModeConfig['documentMode']>
+type DocumentModeType = `${DocumentModeEnum}`
+
+export type GenericSdkConfig = Omit<Parameters<typeof typescriptGenericSdk>[2], 'documentMode'> & {
+  documentMode?: DocumentModeType
+}
 
 export type CodegenClientConfig = TypeScriptPluginConfig & TypeScriptDocumentsPluginConfig & {
   endpoint?: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import type { TypeScriptPluginConfig } from '@graphql-codegen/typescript'
+import type { plugin as typescriptGenericSdk } from '@graphql-codegen/typescript-generic-sdk'
 import type { TypeScriptDocumentsPluginConfig } from '@graphql-codegen/typescript-operations'
 import type { TypeScriptResolversPluginConfig } from '@graphql-codegen/typescript-resolvers'
 import type { IResolvers } from '@graphql-tools/utils'
@@ -7,6 +8,13 @@ import type { ESMCodeGenOptions } from 'knitwork'
 export type { StandardSchemaV1 } from './standard-schema'
 
 export type CodegenServerConfig = TypeScriptPluginConfig & TypeScriptResolversPluginConfig
+
+// CODEGEN
+export type GenericSdkConfig = Parameters<typeof typescriptGenericSdk>[2]
+
+export type CodegenClientConfig = TypeScriptPluginConfig & TypeScriptDocumentsPluginConfig & {
+  endpoint?: string
+}
 
 interface IESMImport {
   name: string
@@ -53,11 +61,6 @@ declare module 'nitropack' {
   }
 }
 
-export interface CodegenClientConfig extends TypeScriptPluginConfig, TypeScriptDocumentsPluginConfig {
-  endpoint?: string
-  documentMode?: 'string' | 'graphQLTag' | 'documentNode' | 'documentNodeImportFragments' | 'external'
-}
-
 export interface NitroGraphQLOptions {
   framework: 'graphql-yoga' | 'apollo-server'
   endpoint?: {
@@ -75,5 +78,6 @@ export interface NitroGraphQLOptions {
   codegen?: {
     server?: CodegenServerConfig
     client?: CodegenClientConfig
+    clientSDK?: GenericSdkConfig
   }
 }

--- a/src/utils/client-codegen.ts
+++ b/src/utils/client-codegen.ts
@@ -1,7 +1,7 @@
 import type { LoadSchemaOptions, UnnormalizedTypeDefPointer } from '@graphql-tools/load'
 import type { Source } from '@graphql-tools/utils'
 import type { GraphQLSchema } from 'graphql'
-import type { CodegenClientConfig } from '../types'
+import type { CodegenClientConfig, GenericSdkConfig } from '../types'
 import { codegen } from '@graphql-codegen/core'
 import { preset } from '@graphql-codegen/import-types-preset'
 import { plugin as typescriptPlugin } from '@graphql-codegen/typescript'
@@ -111,7 +111,6 @@ export async function generateClientTypes(
   consola.info(`[graphql] Found ${docs.length} client GraphQL documents`)
 
   const defaultConfig: CodegenClientConfig = {
-    documentMode: 'string',
     emitLegacyCommonJSImports: false,
     useTypeImports: true,
     enumsAsTypes: true,
@@ -161,6 +160,7 @@ export async function generateClientTypes(
         dedupeOperationSuffix: true,
         exportFragmentSpreadSubTypes: true,
         enumsAsTypes: true,
+        rawRequest: true,
         scalars: {
           DateTime: 'Date',
           JSON: 'any',
@@ -168,13 +168,13 @@ export async function generateClientTypes(
           NonEmptyString: 'string',
           Currency: 'string',
         },
-      },
+      } as GenericSdkConfig,
       presetConfig: {
         typesPath: '#graphql/client',
       },
       plugins: [
         { pluginContent: {} },
-        { typescriptGenericSdk: { rawRequest: false } },
+        { typescriptGenericSdk: { } },
       ],
       pluginMap: {
         pluginContent: { plugin: pluginContent },

--- a/src/utils/client-codegen.ts
+++ b/src/utils/client-codegen.ts
@@ -101,6 +101,7 @@ export async function generateClientTypes(
   schema: GraphQLSchema,
   docs: Source[],
   config: CodegenClientConfig = {},
+  sdkConfig: GenericSdkConfig = {},
   outputPath?: string,
 ) {
   if (docs.length === 0) {
@@ -128,6 +129,25 @@ export async function generateClientTypes(
 
   const mergedConfig = defu(config, defaultConfig)
 
+  const defaultSdkConfig: GenericSdkConfig = {
+    documentMode: 'string',
+    pureMagicComment: true,
+    strictScalars: true,
+    useTypeImports: true,
+    dedupeOperationSuffix: true,
+    rawRequest: true,
+
+    scalars: {
+      DateTime: 'Date',
+      JSON: 'any',
+      UUID: 'string',
+      NonEmptyString: 'string',
+      Currency: 'string',
+    },
+  }
+
+  const mergedSdkConfig = defu(sdkConfig, defaultSdkConfig)
+
   try {
     const output = await codegen({
       filename: outputPath || 'client-types.generated.ts',
@@ -150,25 +170,7 @@ export async function generateClientTypes(
       baseOutputDir: outputPath || 'client-types.generated.ts',
       schema: parse(printSchemaWithDirectives(schema)),
       documents: [...docs],
-      config: {
-        fetcher: 'function',
-        documentMode: 'string',
-        pureMagicComment: true,
-        strictScalars: true,
-        avoidOptionals: true,
-        useTypeImports: true,
-        dedupeOperationSuffix: true,
-        exportFragmentSpreadSubTypes: true,
-        enumsAsTypes: true,
-        rawRequest: true,
-        scalars: {
-          DateTime: 'Date',
-          JSON: 'any',
-          UUID: 'string',
-          NonEmptyString: 'string',
-          Currency: 'string',
-        },
-      } as GenericSdkConfig,
+      config: mergedSdkConfig,
       presetConfig: {
         typesPath: '#graphql/client',
       },

--- a/src/utils/type-generation.ts
+++ b/src/utils/type-generation.ts
@@ -95,7 +95,7 @@ export async function clientTypeGeneration(
     const graphqlString = readFileSync(schemaFilePath, 'utf-8')
     const schema = buildSchema(graphqlString)
 
-    const types = await generateClientTypes(schema, loadDocs, nitro.options.graphql?.codegen?.client ?? {})
+    const types = await generateClientTypes(schema, loadDocs, nitro.options.graphql?.codegen?.client ?? {}, nitro.options.graphql?.codegen?.clientSDK ?? {})
     if (types === false) {
       return
     }


### PR DESCRIPTION
sdk should return data, errors, etc. in return types. For this, the default value rawRequest is true.


new config: clientSDK
```
 graphql: {
      framework: 'graphql-yoga',
      codegen: {
        clientSDK: {
          
        }
      }
    },
```