### PR TITLE
feat!: update context.ts structure and add migration warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -302,18 +302,29 @@ export default defineGraphQLConfig({
 `, 'utf-8')
     }
 
-    if (!existsSync(join(nitro.graphql.serverDir, 'context.d.ts'))) {
-      writeFileSync(join(nitro.graphql.serverDir, 'context.d.ts'), `// Example context definition please change it to your needs
-import type { H3EventContext as OriginalH3EventContext } from 'h3'
-
-export interface ExtendedH3EventContext extends OriginalH3EventContext {
-  // useDatabase: () => Database
-  // tables: typeof import('~~/server/drizzle/schema/index')
-}
+    if (!existsSync(join(nitro.graphql.serverDir, 'context.ts'))) {
+      writeFileSync(join(nitro.graphql.serverDir, 'context.ts'), `// Example context definition - please change it to your needs
+// import type { Database } from '../utils/useDb'
 
 declare module 'h3' {
-  interface H3EventContext extends ExtendedH3EventContext {}
+  interface H3EventContext {
+    // Add your custom context properties here
+    // useDatabase: () => Database
+    // tables: typeof import('../drizzle/schema')
+    // auth?: {
+    //   user?: {
+    //     id: string
+    //     role: 'admin' | 'user'
+    //   }
+    // }
+  }
 }`, 'utf-8')
+    }
+
+    // Check for old context.d.ts file and warn users to migrate
+    if (existsSync(join(nitro.graphql.serverDir, 'context.d.ts'))) {
+      consola.warn('nitro-graphql: Found context.d.ts file. Please rename it to context.ts for the new structure.')
+      consola.info('The context file should now be context.ts instead of context.d.ts')
     }
   },
 })


### PR DESCRIPTION
## Summary
- Updated context.ts template to use modern TypeScript module augmentation pattern
- Added warning for users with old context.d.ts files to migrate to context.ts
- Simplified the context structure by removing unnecessary intermediate interface

## Breaking Changes
Users with existing `context.d.ts` files will need to rename them to `context.ts` for compatibility with the new structure.

## Changes Made
1. **Simplified context.ts template**: Now directly extends H3EventContext without creating an ExtendedH3EventContext interface
2. **Added migration warning**: When the module detects an old context.d.ts file, it will warn users to rename it to context.ts
3. **Updated example**: The template now shows the modern pattern used in production projects

## Migration Guide
If you have a `context.d.ts` file, simply rename it to `context.ts`. The new pattern directly extends the H3EventContext interface:

```typescript
// Old pattern (context.d.ts)
export interface ExtendedH3EventContext extends OriginalH3EventContext {
  // properties
}

declare module 'h3' {
  interface H3EventContext extends ExtendedH3EventContext {}
}

// New pattern (context.ts)
declare module 'h3' {
  interface H3EventContext {
    // properties
  }
}
```