### PR TITLE
feat: auto-create app/graphql directory for Nuxt projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nitro-graphql",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "packageManager": "pnpm@10.13.1",
   "description": "GraphQL integration for Nitro",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,8 @@ export default defineNitroModule({
       for (const service of nitro.options.graphql.externalServices) {
         if (service.documents?.length) {
           for (const pattern of service.documents) {
+            if (!pattern)
+              continue
             // Extract directory from pattern for watching
             const baseDir = pattern.split('**')[0].replace(/\/$/, '') || '.'
             const resolvedDir = resolve(nitro.options.rootDir, baseDir)
@@ -384,6 +386,35 @@ declare module 'h3' {
     if (existsSync(join(nitro.graphql.serverDir, 'context.d.ts'))) {
       consola.warn('nitro-graphql: Found context.d.ts file. Please rename it to context.ts for the new structure.')
       consola.info('The context file should now be context.ts instead of context.d.ts')
+    }
+
+    // Create client directory for Nuxt projects
+    if (nitro.options.framework.name === 'nuxt') {
+      if (!existsSync(nitro.graphql.clientDir)) {
+        mkdirSync(nitro.graphql.clientDir, { recursive: true })
+      }
+
+      // Create default subdirectory for the new folder structure
+      const defaultDir = join(nitro.graphql.clientDir, 'default')
+      if (!existsSync(defaultDir)) {
+        mkdirSync(defaultDir, { recursive: true })
+      }
+
+      // Create a sample GraphQL query file to help users get started
+      const sampleQueryFile = join(defaultDir, 'queries.graphql')
+      if (!existsSync(sampleQueryFile)) {
+        writeFileSync(sampleQueryFile, `# Example GraphQL queries
+# Add your GraphQL queries here
+
+# query GetUser($id: ID!) {
+#   user(id: $id) {
+#     id
+#     name
+#     email
+#   }
+# }
+`, 'utf-8')
+      }
     }
   },
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ export default defineNitroModule({
             if (!pattern)
               continue
             // Extract directory from pattern for watching
-            const baseDir = pattern.split('**')[0].replace(/\/$/, '') || '.'
+            const baseDir = pattern.split('**')[0]?.replace(/\/$/, '') || '.'
             const resolvedDir = resolve(nitro.options.rootDir, baseDir)
             if (!watchDirs.includes(resolvedDir)) {
               watchDirs.push(resolvedDir)


### PR DESCRIPTION
## Summary
- Automatically create `app/graphql` directory when framework is Nuxt
- Create `app/graphql/default` subdirectory for new folder structure  
- Add sample `queries.graphql` file to help users get started
- Fix TypeScript error with optional chaining for external service patterns

## Test plan
- [x] Build module successfully
- [x] Test in playground-nuxt to verify directory creation
- [x] Verify sample file is created correctly
- [x] Fix TypeScript linting errors

Fixes the issue where users had to manually create the `app/graphql` directory in Nuxt projects. Now it's created automatically like `server/graphql`, improving the developer experience.