### PR TITLE
fix: improve ofetch.ts generation logic for external services

### DIFF
--- a/src/utils/type-generation.ts
+++ b/src/utils/type-generation.ts
@@ -231,13 +231,9 @@ async function generateMainClientTypes(nitro: Nitro) {
 
   // Generate ofetch client for Nuxt framework
   if (nitro.options.framework?.name === 'nuxt') {
-    // Check if user has their own app/graphql setup
-    const appGraphqlDir = resolve(nitro.options.rootDir, 'app/graphql')
-    const hasUserGraphqlSetup = existsSync(appGraphqlDir)
-
-    if (!hasUserGraphqlSetup) {
-      generateNuxtOfetchClient(nitro.graphql.clientDir, 'default')
-    }
+    // Always generate default service ofetch client (only if it doesn't exist)
+    generateNuxtOfetchClient(nitro.graphql.clientDir, 'default')
+    
     const externalServices = nitro.options.graphql?.externalServices || []
     generateGraphQLIndexFile(nitro.graphql.clientDir, externalServices)
   }
@@ -267,9 +263,14 @@ async function generateExternalServicesTypes(nitro: Nitro) {
       if (documentPatterns.length > 0) {
         try {
           loadDocs = await loadGraphQLDocuments(documentPatterns)
+          if (!loadDocs || loadDocs.length === 0) {
+            consola.warn(`[graphql:${service.name}] No GraphQL documents found, skipping service generation`)
+            continue
+          }
         }
         catch (error) {
-          consola.warn(`[graphql:${service.name}] No documents found:`, error)
+          consola.warn(`[graphql:${service.name}] No documents found, skipping service generation:`, error)
+          continue
         }
       }
 

--- a/src/utils/type-generation.ts
+++ b/src/utils/type-generation.ts
@@ -233,7 +233,7 @@ async function generateMainClientTypes(nitro: Nitro) {
   if (nitro.options.framework?.name === 'nuxt') {
     // Always generate default service ofetch client (only if it doesn't exist)
     generateNuxtOfetchClient(nitro.graphql.clientDir, 'default')
-    
+
     const externalServices = nitro.options.graphql?.externalServices || []
     generateGraphQLIndexFile(nitro.graphql.clientDir, externalServices)
   }


### PR DESCRIPTION
## Summary
• Fixed default service ofetch.ts generation - now creates files even when user has app/graphql setup
• Added validation to skip external service generation when no GraphQL documents are found  
• Enabled external services in playground for testing

## Changes
- Removed restrictive `hasUserGraphqlSetup` check in `generateMainClientTypes`
- Added document validation in `generateExternalServicesTypes` to skip services without GraphQL files
- Uncommented countries external service in playground-nuxt config

## Test plan
- [ ] Verify default/ofetch.ts is generated in playground-nuxt
- [ ] Verify external services without documents don't generate SDK files
- [ ] Test that external services with documents still work correctly

Closes #26