### PR TITLE
fix: exclude external service documents from main client type generation

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -173,9 +173,34 @@ export async function scanSchemas(nitro: Nitro) {
 
 export async function scanDocs(nitro: Nitro) {
   const files = await scanDir(nitro, nitro.options.rootDir, nitro.graphql.dir.client, '**/*.graphql')
-  // Filter out files in the external directory
+
+  // Get external service document patterns to filter out
+  const externalServices = nitro.options.graphql?.externalServices || []
+  const externalPatterns = externalServices.flatMap(service => service.documents || [])
+
+  // Filter out files in the external directory and files matching external service patterns
   return files
     .filter(f => !f.path.startsWith('external/'))
+    .filter((f) => {
+      // Check if this file matches any external service document patterns
+      const relativePath = f.path
+
+      for (const pattern of externalPatterns) {
+        // Remove the leading 'app/graphql/' from patterns to match relative paths
+        const cleanPattern = pattern.replace(/^app\/graphql\//, '')
+
+        // Extract directory name from pattern for matching
+        const patternDir = cleanPattern.split('/')[0]
+        const fileDir = relativePath.split('/')[0]
+
+        // If the file is in a directory that's part of an external service pattern, exclude it
+        if (patternDir === fileDir) {
+          return false
+        }
+      }
+
+      return true
+    })
     .map(f => f.fullPath)
 }
 


### PR DESCRIPTION
## Summary
- Fixed GraphQL Document Validation errors when using external services
- Enhanced `scanDocs` function to properly filter external service documents
- Prevents external service queries from being validated against local schema

## Problem
External service document files were being incorrectly included in the main client type generation process and validated against the local server schema, causing validation failures when external service queries referenced fields not present in the local schema.

This resulted in errors like:
```
Cannot query field "countries" on type "Query"
Cannot query field "country" on type "Query"
```

## Solution
Enhanced the `scanDocs` function in `src/utils/index.ts` to:
1. Extract document patterns from configured external services
2. Filter out files that match external service document patterns
3. Ensure external service documents are only validated against their respective schemas

## Test plan
- [x] Built the module successfully with `pnpm build`
- [x] Tested with Nuxt playground - no more validation errors
- [x] Confirmed external service types are still generated correctly
- [x] Verified both local and external GraphQL services work as expected

## Impact
- Resolves client type generation failures when using external GraphQL services
- Maintains proper separation between local and external service document validation
- No breaking changes to existing functionality