### PR TITLE
feat: add full file generation control and custom path system

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,246 @@ query {
 ## 🚀 Advanced Features
 
 <details>
+<summary><strong>🎛️ Custom File Generation & Paths</strong></summary>
+
+Control which files are auto-generated and customize their output paths. Perfect for library development, monorepos, or custom project structures.
+
+### Library Mode
+
+Disable all scaffold files for library/module development:
+
+```ts
+// nitro.config.ts
+export default defineNitroConfig({
+  graphql: {
+    framework: 'graphql-yoga',
+    scaffold: false,        // Disable all scaffold files
+    clientUtils: false,     // Disable client utilities
+  }
+})
+```
+
+### Fine-Grained Control
+
+Control each file individually:
+
+```ts
+export default defineNitroConfig({
+  graphql: {
+    framework: 'graphql-yoga',
+
+    // Scaffold files
+    scaffold: {
+      graphqlConfig: false,     // Don't generate graphql.config.ts
+      serverSchema: true,       // Generate server/graphql/schema.ts
+      serverConfig: true,       // Generate server/graphql/config.ts
+      serverContext: false,     // Don't generate server/graphql/context.ts
+    },
+
+    // Client utilities (Nuxt only)
+    clientUtils: {
+      index: true,              // Generate app/graphql/index.ts
+      ofetch: false,            // Don't generate ofetch wrappers
+    },
+
+    // SDK files
+    sdk: {
+      main: true,               // Generate default SDK
+      external: true,           // Generate external service SDKs
+    },
+
+    // Type files
+    types: {
+      server: true,             // Generate server types
+      client: true,             // Generate client types
+      external: true,           // Generate external service types
+    }
+  }
+})
+```
+
+### Custom Paths
+
+Customize where files are generated:
+
+```ts
+export default defineNitroConfig({
+  graphql: {
+    framework: 'graphql-yoga',
+
+    // Method 1: Global paths (affects all files)
+    paths: {
+      serverGraphql: 'src/server/graphql',
+      clientGraphql: 'src/client/graphql',
+      buildDir: '.build',
+      typesDir: '.build/types',
+    },
+
+    // Method 2: Specific file paths
+    scaffold: {
+      serverSchema: 'lib/graphql/schema.ts',
+      serverConfig: 'lib/graphql/config.ts',
+    },
+
+    sdk: {
+      main: 'app/graphql/organization/sdk.ts',
+      external: 'app/graphql/{serviceName}/client-sdk.ts',
+    },
+
+    types: {
+      server: 'types/graphql-server.d.ts',
+      client: 'types/graphql-client.d.ts',
+    }
+  }
+})
+```
+
+### Path Placeholders
+
+Use placeholders in custom paths:
+
+| Placeholder | Description | Example |
+|------------|-------------|---------|
+| `{serviceName}` | External service name | `github`, `stripe` |
+| `{buildDir}` | Build directory | `.nitro` or `.nuxt` |
+| `{rootDir}` | Root directory | `/Users/you/project` |
+| `{framework}` | Framework name | `nuxt` or `nitro` |
+| `{typesDir}` | Types directory | `.nitro/types` |
+| `{serverGraphql}` | Server GraphQL dir | `server/graphql` |
+| `{clientGraphql}` | Client GraphQL dir | `app/graphql` |
+
+Example:
+```ts
+sdk: {
+  external: '{clientGraphql}/{serviceName}/sdk.ts'
+}
+// → app/graphql/github/sdk.ts
+// → app/graphql/stripe/sdk.ts
+```
+
+### Service-Specific Paths
+
+Customize paths for individual external services:
+
+```ts
+export default defineNuxtConfig({
+  nitro: {
+    graphql: {
+      framework: 'graphql-yoga',
+
+      // Global default for all external services
+      sdk: {
+        external: 'app/graphql/{serviceName}/sdk.ts'
+      },
+
+      externalServices: [
+        {
+          name: 'github',
+          endpoint: 'https://api.github.com/graphql',
+          schema: 'https://api.github.com/graphql',
+
+          // GitHub-specific paths (override global config)
+          paths: {
+            sdk: 'app/graphql/organization/github-sdk.ts',
+            types: 'types/github.d.ts',
+            ofetch: 'app/graphql/organization/github-client.ts'
+          }
+        },
+        {
+          name: 'stripe',
+          endpoint: 'https://api.stripe.com/graphql',
+          schema: 'https://api.stripe.com/graphql',
+
+          // Stripe-specific paths
+          paths: {
+            sdk: 'app/graphql/payments/stripe-sdk.ts',
+            types: 'types/payments/stripe.d.ts',
+            // ofetch uses global config
+          }
+        },
+        {
+          name: 'shopify',
+          endpoint: 'https://api.shopify.com/graphql',
+          // No paths → uses global config
+          // → app/graphql/shopify/sdk.ts
+        }
+      ]
+    }
+  }
+})
+```
+
+### Path Resolution Priority
+
+When resolving file paths, the system follows this priority order:
+
+1. **Service-specific path** (for external services): `service.paths.sdk`
+2. **Category config**: `sdk.external` or `sdk.main`
+3. **Global paths**: `paths.clientGraphql`
+4. **Framework defaults**: Nuxt vs Nitro defaults
+
+Example:
+```ts
+// Given this config:
+{
+  paths: { clientGraphql: 'custom/graphql' },
+  sdk: { external: '{clientGraphql}/{serviceName}/sdk.ts' },
+  externalServices: [
+    {
+      name: 'github',
+      paths: { sdk: 'app/org/github-sdk.ts' }  // ← Wins (priority 1)
+    },
+    {
+      name: 'stripe',
+      // Uses sdk.external (priority 2)
+      // → custom/graphql/stripe/sdk.ts
+    }
+  ]
+}
+```
+
+### Use Cases
+
+**Monorepo structure:**
+```ts
+paths: {
+  serverGraphql: 'packages/api/src/graphql',
+  clientGraphql: 'packages/web/src/graphql',
+  typesDir: 'packages/types/src/generated',
+}
+```
+
+**Multiple external service organizations:**
+```ts
+externalServices: [
+  {
+    name: 'github',
+    paths: { sdk: 'app/graphql/vcs/github-sdk.ts' }
+  },
+  {
+    name: 'gitlab',
+    paths: { sdk: 'app/graphql/vcs/gitlab-sdk.ts' }
+  },
+  {
+    name: 'stripe',
+    paths: { sdk: 'app/graphql/billing/stripe-sdk.ts' }
+  }
+]
+```
+
+**Library development (no scaffolding):**
+```ts
+{
+  scaffold: false,
+  clientUtils: false,
+  sdk: { enabled: true },    // Only generate SDKs
+  types: { enabled: true },  // Only generate types
+}
+```
+
+</details>
+
+<details>
 <summary><strong>🎭 Custom Directives</strong></summary>
 
 Create reusable GraphQL directives:

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,13 @@ import {
   scanSchemas,
   validateExternalServices,
 } from './utils'
+import { writeFileIfNotExists } from './utils/file-generator'
+import {
+  getDefaultPaths,
+  getScaffoldConfig,
+  resolveFilePath,
+  shouldGenerateScaffold,
+} from './utils/path-resolver'
 import { clientTypeGeneration, serverTypeGeneration } from './utils/type-generation'
 
 export type * from './types'
@@ -437,11 +444,28 @@ export default defineNitroModule({
       })
     }
 
-    if (!existsSync(join(nitro.options.rootDir, 'graphql.config.ts'))) {
-      const schemaPath = relativeWithDot(nitro.options.rootDir, resolve(nitro.graphql.buildDir, 'schema.graphql'))
-      const documentsPath = relativeWithDot(nitro.options.rootDir, resolve(nitro.graphql.clientDir, '**/*.{graphql,js,ts,jsx,tsx}'))
+    // ==================== SCAFFOLD FILE GENERATION ====================
+    // Generate scaffold files based on configuration
+    // Can be disabled via: scaffold: false or scaffold.enabled: false
 
-      writeFileSync(join(nitro.options.rootDir, 'graphql.config.ts'), `
+    if (shouldGenerateScaffold(nitro)) {
+      const placeholders = getDefaultPaths(nitro)
+      const scaffoldConfig = getScaffoldConfig(nitro)
+
+      // 1. graphql.config.ts - GraphQL Config for IDE tooling
+      const graphqlConfigPath = resolveFilePath(
+        scaffoldConfig.graphqlConfig,
+        scaffoldConfig.enabled,
+        true,
+        'graphql.config.ts',
+        placeholders,
+      )
+
+      if (graphqlConfigPath) {
+        const schemaPath = relativeWithDot(nitro.options.rootDir, resolve(nitro.graphql.buildDir, 'schema.graphql'))
+        const documentsPath = relativeWithDot(nitro.options.rootDir, resolve(nitro.graphql.clientDir, '**/*.{graphql,js,ts,jsx,tsx}'))
+
+        writeFileIfNotExists(graphqlConfigPath, `
 import type { IGraphQLConfig } from 'graphql-config'
 
 export default <IGraphQLConfig> {
@@ -455,22 +479,50 @@ export default <IGraphQLConfig> {
         ],
       },
     },
-}`, 'utf-8')
-    }
+}`, 'graphql.config.ts')
+      }
 
-    if (!existsSync(nitro.graphql.serverDir)) {
-      mkdirSync(nitro.graphql.serverDir, { recursive: true })
-    }
+      // Ensure server GraphQL directory exists if any server files will be generated
+      const serverSchemaPath = resolveFilePath(
+        scaffoldConfig.serverSchema,
+        scaffoldConfig.enabled,
+        true,
+        '{serverGraphql}/schema.ts',
+        placeholders,
+      )
+      const serverConfigPath = resolveFilePath(
+        scaffoldConfig.serverConfig,
+        scaffoldConfig.enabled,
+        true,
+        '{serverGraphql}/config.ts',
+        placeholders,
+      )
+      const serverContextPath = resolveFilePath(
+        scaffoldConfig.serverContext,
+        scaffoldConfig.enabled,
+        true,
+        '{serverGraphql}/context.ts',
+        placeholders,
+      )
 
-    if (!existsSync(join(nitro.graphql.serverDir, 'schema.ts'))) {
-      writeFileSync(join(nitro.graphql.serverDir, 'schema.ts'), `export default defineSchema({
+      // Create server directory if any server scaffold files will be generated
+      if (serverSchemaPath || serverConfigPath || serverContextPath) {
+        if (!existsSync(nitro.graphql.serverDir)) {
+          mkdirSync(nitro.graphql.serverDir, { recursive: true })
+        }
+      }
+
+      // 2. server/graphql/schema.ts - Schema definition file
+      if (serverSchemaPath) {
+        writeFileIfNotExists(serverSchemaPath, `export default defineSchema({
 
 })
-`, 'utf-8')
-    }
+`, 'server schema.ts')
+      }
 
-    if (!existsSync(join(nitro.graphql.serverDir, 'config.ts'))) {
-      writeFileSync(join(nitro.graphql.serverDir, 'config.ts'), `// Example GraphQL config file please change it to your needs
+      // 3. server/graphql/config.ts - GraphQL server configuration
+      if (serverConfigPath) {
+        writeFileIfNotExists(serverConfigPath, `// Example GraphQL config file please change it to your needs
 // import * as tables from '../drizzle/schema/index'
 // import { useDatabase } from '../utils/useDb'
 
@@ -485,11 +537,12 @@ export default defineGraphQLConfig({
 //   }
 // },
 })
-`, 'utf-8')
-    }
+`, 'server config.ts')
+      }
 
-    if (!existsSync(join(nitro.graphql.serverDir, 'context.ts'))) {
-      writeFileSync(join(nitro.graphql.serverDir, 'context.ts'), `// Example context definition - please change it to your needs
+      // 4. server/graphql/context.ts - H3 context augmentation
+      if (serverContextPath) {
+        writeFileIfNotExists(serverContextPath, `// Example context definition - please change it to your needs
 // import type { Database } from '../utils/useDb'
 
 declare module 'h3' {
@@ -504,13 +557,17 @@ declare module 'h3' {
     //   }
     // }
   }
-}`, 'utf-8')
-    }
+}`, 'server context.ts')
+      }
 
-    // Check for old context.d.ts file and warn users to migrate
-    if (existsSync(join(nitro.graphql.serverDir, 'context.d.ts'))) {
-      consola.warn('nitro-graphql: Found context.d.ts file. Please rename it to context.ts for the new structure.')
-      consola.info('The context file should now be context.ts instead of context.d.ts')
+      // Check for old context.d.ts file and warn users to migrate
+      if (existsSync(join(nitro.graphql.serverDir, 'context.d.ts'))) {
+        consola.warn('nitro-graphql: Found context.d.ts file. Please rename it to context.ts for the new structure.')
+        consola.info('The context file should now be context.ts instead of context.d.ts')
+      }
+    }
+    else {
+      consola.info('[nitro-graphql] Scaffold file generation is disabled (library mode)')
     }
   },
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { Nitro } from 'nitropack/types'
 import type { NitroGraphQLOptions } from './types'
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { watch } from 'chokidar'
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,19 @@ declare module 'nitropack' {
   }
 }
 
+/**
+ * Service-specific path overrides for external GraphQL services
+ * These paths override global config for this specific service
+ */
+export interface ExternalServicePaths {
+  /** SDK file path (overrides global sdk.external config) */
+  sdk?: FileGenerationConfig
+  /** Type definitions file path (overrides global types.external config) */
+  types?: FileGenerationConfig
+  /** ofetch client wrapper path (overrides global clientUtils.ofetch config) */
+  ofetch?: FileGenerationConfig
+}
+
 export interface ExternalGraphQLService {
   /** Unique name for this service (used for file naming and type generation) */
   name: string
@@ -94,6 +107,12 @@ export interface ExternalGraphQLService {
     client?: CodegenClientConfig
     clientSDK?: GenericSdkConfig
   }
+  /**
+   * Optional: Service-specific path overrides
+   * These paths take precedence over global config (sdk, types, clientUtils)
+   * Supports placeholders: {serviceName}, {buildDir}, {rootDir}, {framework}, {typesDir}, {clientGraphql}
+   */
+  paths?: ExternalServicePaths
 }
 
 export interface FederationConfig {
@@ -105,6 +124,87 @@ export interface FederationConfig {
   serviceVersion?: string
   /** Service URL for federation gateway */
   serviceUrl?: string
+}
+
+/**
+ * File generation control:
+ * - false: Do not generate this file
+ * - true: Generate at default location
+ * - string: Generate at custom path (supports placeholders: {serviceName}, {buildDir}, {rootDir}, {framework})
+ */
+export type FileGenerationConfig = boolean | string
+
+/**
+ * Scaffold files configuration
+ * Control auto-generation of scaffold/boilerplate files
+ */
+export interface ScaffoldConfig {
+  /** Enable/disable all scaffold files */
+  enabled?: boolean
+  /** graphql.config.ts - GraphQL Config file for IDE tooling */
+  graphqlConfig?: FileGenerationConfig
+  /** server/graphql/schema.ts - Schema definition file */
+  serverSchema?: FileGenerationConfig
+  /** server/graphql/config.ts - GraphQL server configuration */
+  serverConfig?: FileGenerationConfig
+  /** server/graphql/context.ts - H3 context augmentation */
+  serverContext?: FileGenerationConfig
+}
+
+/**
+ * Client utilities configuration
+ * Control auto-generation of client-side utility files (Nuxt only)
+ */
+export interface ClientUtilsConfig {
+  /** Enable/disable all client utilities */
+  enabled?: boolean
+  /** app/graphql/index.ts - Main exports file */
+  index?: FileGenerationConfig
+  /** app/graphql/{serviceName}/ofetch.ts - ofetch client wrapper */
+  ofetch?: FileGenerationConfig
+}
+
+/**
+ * SDK files configuration
+ * Control auto-generation of GraphQL SDK files
+ */
+export interface SdkConfig {
+  /** Enable/disable all SDK files */
+  enabled?: boolean
+  /** app/graphql/default/sdk.ts - Main service SDK */
+  main?: FileGenerationConfig
+  /** app/graphql/{serviceName}/sdk.ts - External service SDKs */
+  external?: FileGenerationConfig
+}
+
+/**
+ * Type files configuration
+ * Control auto-generation of TypeScript type definition files
+ */
+export interface TypesConfig {
+  /** Enable/disable all type files */
+  enabled?: boolean
+  /** .nitro/types/nitro-graphql-server.d.ts - Server-side types */
+  server?: FileGenerationConfig
+  /** .nitro/types/nitro-graphql-client.d.ts - Client-side types */
+  client?: FileGenerationConfig
+  /** .nitro/types/nitro-graphql-client-{serviceName}.d.ts - External service types */
+  external?: FileGenerationConfig
+}
+
+/**
+ * Global path overrides
+ * Set base directories for file generation
+ */
+export interface PathsConfig {
+  /** Server GraphQL directory (default: 'server/graphql') */
+  serverGraphql?: string
+  /** Client GraphQL directory (default: 'app/graphql' for Nuxt, 'graphql' for Nitro) */
+  clientGraphql?: string
+  /** Build directory (default: '.nitro' or '.nuxt') */
+  buildDir?: string
+  /** Types directory (default: '{buildDir}/types') */
+  typesDir?: string
 }
 
 export interface NitroGraphQLOptions {
@@ -136,4 +236,29 @@ export interface NitroGraphQLOptions {
   layerDirectories?: string[]
   layerServerDirs?: string[]
   layerAppDirs?: string[]
+  /**
+   * Scaffold files configuration
+   * Set to false to disable all scaffold file generation (library mode)
+   */
+  scaffold?: false | ScaffoldConfig
+  /**
+   * Client utilities configuration
+   * Set to false to disable all client utility generation
+   */
+  clientUtils?: false | ClientUtilsConfig
+  /**
+   * SDK files configuration
+   * Set to false to disable all SDK generation
+   */
+  sdk?: false | SdkConfig
+  /**
+   * Type files configuration
+   * Set to false to disable all type generation
+   */
+  types?: false | TypesConfig
+  /**
+   * Global path overrides
+   * Customize base directories for file generation
+   */
+  paths?: PathsConfig
 }

--- a/src/utils/file-generator.ts
+++ b/src/utils/file-generator.ts
@@ -1,0 +1,103 @@
+import type { Nitro } from 'nitropack/types'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import consola from 'consola'
+import { dirname } from 'pathe'
+
+/**
+ * Safely write a file to disk, creating parent directories if needed
+ */
+export function writeFile(filePath: string, content: string, description?: string): void {
+  try {
+    // Create parent directory if it doesn't exist
+    const dir = dirname(filePath)
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true })
+    }
+
+    writeFileSync(filePath, content, 'utf-8')
+
+    if (description) {
+      consola.success(`[nitro-graphql] Generated: ${description}`)
+    }
+  }
+  catch (error) {
+    consola.error(`[nitro-graphql] Failed to write file: ${filePath}`, error)
+    throw error
+  }
+}
+
+/**
+ * Write a file only if it doesn't already exist
+ * Returns true if file was created, false if it already existed
+ */
+export function writeFileIfNotExists(
+  filePath: string,
+  content: string,
+  description?: string,
+): boolean {
+  if (existsSync(filePath)) {
+    return false
+  }
+
+  writeFile(filePath, content, description)
+  return true
+}
+
+/**
+ * Write a file and always overwrite (used for generated files like SDK)
+ * This is for files that are auto-generated and should be updated on every build
+ */
+export function writeGeneratedFile(
+  filePath: string,
+  content: string,
+  description?: string,
+): void {
+  writeFile(filePath, content, description)
+}
+
+/**
+ * Check if a path is configured and should be generated
+ * Returns the resolved path if should generate, null otherwise
+ */
+export function getGenerationPath(
+  resolvedPath: string | null,
+  description?: string,
+): string | null {
+  if (!resolvedPath) {
+    if (description) {
+      consola.debug(`[nitro-graphql] Skipping generation: ${description} (disabled in config)`)
+    }
+    return null
+  }
+
+  return resolvedPath
+}
+
+/**
+ * Log skipped file generation (helpful for debugging library mode)
+ */
+export function logSkipped(fileName: string, reason?: string): void {
+  const message = reason
+    ? `Skipped ${fileName}: ${reason}`
+    : `Skipped ${fileName}`
+  consola.debug(`[nitro-graphql] ${message}`)
+}
+
+/**
+ * Log generated file path
+ */
+export function logGenerated(fileName: string, path: string): void {
+  consola.info(`[nitro-graphql] Generated ${fileName} at: ${path}`)
+}
+
+/**
+ * Validate that a Nitro instance has the required GraphQL configuration
+ */
+export function validateGraphQLConfig(nitro: Nitro): boolean {
+  if (!nitro.options.graphql?.framework) {
+    consola.warn('[nitro-graphql] No GraphQL framework specified. Some features may not work correctly.')
+    return false
+  }
+
+  return true
+}

--- a/src/utils/path-resolver.ts
+++ b/src/utils/path-resolver.ts
@@ -27,13 +27,13 @@ export interface PathPlaceholders {
  */
 export function replacePlaceholders(path: string, placeholders: PathPlaceholders): string {
   return path
-    .replace(/{serviceName}/g, placeholders.serviceName || 'default')
-    .replace(/{buildDir}/g, placeholders.buildDir)
-    .replace(/{rootDir}/g, placeholders.rootDir)
-    .replace(/{framework}/g, placeholders.framework)
-    .replace(/{typesDir}/g, placeholders.typesDir)
-    .replace(/{serverGraphql}/g, placeholders.serverGraphql)
-    .replace(/{clientGraphql}/g, placeholders.clientGraphql)
+    .replace(/\{serviceName\}/g, placeholders.serviceName || 'default')
+    .replace(/\{buildDir\}/g, placeholders.buildDir)
+    .replace(/\{rootDir\}/g, placeholders.rootDir)
+    .replace(/\{framework\}/g, placeholders.framework)
+    .replace(/\{typesDir\}/g, placeholders.typesDir)
+    .replace(/\{serverGraphql\}/g, placeholders.serverGraphql)
+    .replace(/\{clientGraphql\}/g, placeholders.clientGraphql)
 }
 
 /**

--- a/src/utils/path-resolver.ts
+++ b/src/utils/path-resolver.ts
@@ -1,0 +1,233 @@
+import type { Nitro } from 'nitropack/types'
+import type {
+  ClientUtilsConfig,
+  FileGenerationConfig,
+  ScaffoldConfig,
+  SdkConfig,
+  TypesConfig,
+} from '../types'
+import { resolve } from 'pathe'
+
+/**
+ * Placeholder values for path resolution
+ */
+export interface PathPlaceholders {
+  serviceName?: string
+  buildDir: string
+  rootDir: string
+  framework: 'nuxt' | 'nitro'
+  typesDir: string
+  serverGraphql: string
+  clientGraphql: string
+}
+
+/**
+ * Replace placeholders in a path string
+ * Supports: {serviceName}, {buildDir}, {rootDir}, {framework}, {typesDir}, {serverGraphql}, {clientGraphql}
+ */
+export function replacePlaceholders(path: string, placeholders: PathPlaceholders): string {
+  return path
+    .replace(/{serviceName}/g, placeholders.serviceName || 'default')
+    .replace(/{buildDir}/g, placeholders.buildDir)
+    .replace(/{rootDir}/g, placeholders.rootDir)
+    .replace(/{framework}/g, placeholders.framework)
+    .replace(/{typesDir}/g, placeholders.typesDir)
+    .replace(/{serverGraphql}/g, placeholders.serverGraphql)
+    .replace(/{clientGraphql}/g, placeholders.clientGraphql)
+}
+
+/**
+ * Get default paths based on framework and user configuration
+ */
+export function getDefaultPaths(nitro: Nitro): Required<PathPlaceholders> {
+  const isNuxt = nitro.options.framework?.name === 'nuxt'
+  const rootDir = nitro.options.rootDir
+  const buildDir = nitro.options.buildDir
+
+  // Global path overrides from config
+  const pathsConfig = nitro.options.graphql?.paths || {}
+
+  const defaultServerGraphql = pathsConfig.serverGraphql || resolve(rootDir, 'server', 'graphql')
+  const defaultClientGraphql = pathsConfig.clientGraphql || resolve(rootDir, isNuxt ? 'app/graphql' : 'graphql')
+  const defaultBuildDir = pathsConfig.buildDir || buildDir
+  const defaultTypesDir = pathsConfig.typesDir || resolve(defaultBuildDir, 'types')
+
+  return {
+    serviceName: 'default',
+    buildDir: defaultBuildDir,
+    rootDir,
+    framework: isNuxt ? 'nuxt' : 'nitro',
+    typesDir: defaultTypesDir,
+    serverGraphql: defaultServerGraphql,
+    clientGraphql: defaultClientGraphql,
+  }
+}
+
+/**
+ * Check if a file should be generated based on config
+ * Returns: true if should generate, false if should skip
+ */
+export function shouldGenerateFile(
+  config: FileGenerationConfig | undefined,
+  categoryEnabled: boolean | undefined,
+  topLevelEnabled: boolean,
+): boolean {
+  // Priority 1: Specific file config
+  if (config === false)
+    return false
+  if (config === true || typeof config === 'string')
+    return true
+
+  // Priority 2: Category enabled
+  if (categoryEnabled === false)
+    return false
+  if (categoryEnabled === true)
+    return true
+
+  // Priority 3: Top-level enabled (default behavior)
+  return topLevelEnabled
+}
+
+/**
+ * Resolve the file path based on configuration
+ * Returns: resolved absolute path or null if file should not be generated
+ */
+export function resolveFilePath(
+  config: FileGenerationConfig | undefined,
+  categoryEnabled: boolean | undefined,
+  topLevelEnabled: boolean,
+  defaultPath: string,
+  placeholders: PathPlaceholders,
+): string | null {
+  // Check if should generate
+  if (!shouldGenerateFile(config, categoryEnabled, topLevelEnabled)) {
+    return null
+  }
+
+  // If config is a custom path, use it
+  if (typeof config === 'string') {
+    const customPath = replacePlaceholders(config, placeholders)
+    // Make it absolute if it's relative
+    return resolve(placeholders.rootDir, customPath)
+  }
+
+  // Use default path with placeholder support
+  const resolvedDefault = replacePlaceholders(defaultPath, placeholders)
+  return resolve(placeholders.rootDir, resolvedDefault)
+}
+
+/**
+ * Check if scaffold files should be generated (category-level check)
+ */
+export function shouldGenerateScaffold(nitro: Nitro): boolean {
+  const scaffoldConfig = nitro.options.graphql?.scaffold
+
+  // If scaffold is explicitly false, skip all
+  if (scaffoldConfig === false)
+    return false
+
+  // If scaffold.enabled is explicitly false, skip all
+  if (scaffoldConfig && scaffoldConfig.enabled === false)
+    return false
+
+  // Default: generate scaffold files
+  return true
+}
+
+/**
+ * Get scaffold configuration (handles false case)
+ */
+export function getScaffoldConfig(nitro: Nitro): ScaffoldConfig {
+  const scaffoldConfig = nitro.options.graphql?.scaffold
+  if (scaffoldConfig === false) {
+    return { enabled: false }
+  }
+  return scaffoldConfig || {}
+}
+
+/**
+ * Check if client utilities should be generated (category-level check)
+ */
+export function shouldGenerateClientUtils(nitro: Nitro): boolean {
+  const clientUtilsConfig = nitro.options.graphql?.clientUtils
+
+  // If clientUtils is explicitly false, skip all
+  if (clientUtilsConfig === false)
+    return false
+
+  // If clientUtils.enabled is explicitly false, skip all
+  if (clientUtilsConfig && clientUtilsConfig.enabled === false)
+    return false
+
+  // Default: generate client utils (only for Nuxt)
+  return nitro.options.framework?.name === 'nuxt'
+}
+
+/**
+ * Get client utilities configuration (handles false case)
+ */
+export function getClientUtilsConfig(nitro: Nitro): ClientUtilsConfig {
+  const clientUtilsConfig = nitro.options.graphql?.clientUtils
+  if (clientUtilsConfig === false) {
+    return { enabled: false }
+  }
+  return clientUtilsConfig || {}
+}
+
+/**
+ * Check if SDK files should be generated (category-level check)
+ */
+export function shouldGenerateSDK(nitro: Nitro): boolean {
+  const sdkConfig = nitro.options.graphql?.sdk
+
+  // If sdk is explicitly false, skip all
+  if (sdkConfig === false)
+    return false
+
+  // If sdk.enabled is explicitly false, skip all
+  if (sdkConfig && sdkConfig.enabled === false)
+    return false
+
+  // Default: generate SDK files
+  return true
+}
+
+/**
+ * Get SDK configuration (handles false case)
+ */
+export function getSdkConfig(nitro: Nitro): SdkConfig {
+  const sdkConfig = nitro.options.graphql?.sdk
+  if (sdkConfig === false) {
+    return { enabled: false }
+  }
+  return sdkConfig || {}
+}
+
+/**
+ * Check if type files should be generated (category-level check)
+ */
+export function shouldGenerateTypes(nitro: Nitro): boolean {
+  const typesConfig = nitro.options.graphql?.types
+
+  // If types is explicitly false, skip all
+  if (typesConfig === false)
+    return false
+
+  // If types.enabled is explicitly false, skip all
+  if (typesConfig && typesConfig.enabled === false)
+    return false
+
+  // Default: generate type files
+  return true
+}
+
+/**
+ * Get types configuration (handles false case)
+ */
+export function getTypesConfig(nitro: Nitro): TypesConfig {
+  const typesConfig = nitro.options.graphql?.types
+  if (typesConfig === false) {
+    return { enabled: false }
+  }
+  return typesConfig || {}
+}

--- a/src/utils/type-generation.ts
+++ b/src/utils/type-generation.ts
@@ -9,16 +9,50 @@ import consola from 'consola'
 import { buildSchema, parse } from 'graphql'
 import { basename, dirname, join, resolve } from 'pathe'
 import { downloadAndSaveSchema, generateClientTypes, generateExternalClientTypes, loadExternalSchema, loadGraphQLDocuments } from './client-codegen'
+import { writeFileIfNotExists } from './file-generator'
+import {
+  getClientUtilsConfig,
+  getDefaultPaths,
+  getSdkConfig,
+  getTypesConfig,
+  resolveFilePath,
+  shouldGenerateClientUtils,
+  shouldGenerateSDK,
+  shouldGenerateTypes,
+} from './path-resolver'
 import { generateTypes } from './server-codegen'
 
-function generateGraphQLIndexFile(clientDir: string, externalServices: any[] = []) {
-  const indexPath = resolve(clientDir, 'index.ts')
+function generateGraphQLIndexFile(
+  nitro: Nitro,
+  clientDir: string,
+  externalServices: any[] = [],
+) {
+  // Check if client utils generation is enabled
+  if (!shouldGenerateClientUtils(nitro)) {
+    return
+  }
+
+  const placeholders = getDefaultPaths(nitro)
+  const clientUtilsConfig = getClientUtilsConfig(nitro)
+
+  // Resolve index.ts path
+  const indexPath = resolveFilePath(
+    clientUtilsConfig.index,
+    clientUtilsConfig.enabled,
+    true,
+    '{clientGraphql}/index.ts',
+    placeholders,
+  )
+
+  if (!indexPath) {
+    return
+  }
 
   // Only create index.ts if it doesn't exist
   if (!existsSync(indexPath)) {
     let indexContent = `// This file is auto-generated once by nitro-graphql for quick start
 // You can modify this file according to your needs
-// 
+//
 // Export your main GraphQL service (auto-generated)
 export * from './default/ofetch'
 
@@ -32,15 +66,41 @@ export * from './default/ofetch'
       indexContent += `export * from './${service.name}/ofetch'\n`
     }
 
-    writeFileSync(indexPath, indexContent, 'utf-8')
+    writeFileIfNotExists(indexPath, indexContent, 'client index.ts')
   }
 }
 
-function generateNuxtOfetchClient(clientDir: string, serviceName: string = 'default') {
-  const serviceDir = resolve(clientDir, serviceName)
-  const ofetchPath = resolve(serviceDir, 'ofetch.ts')
+function generateNuxtOfetchClient(
+  nitro: Nitro,
+  clientDir: string,
+  serviceName: string = 'default',
+) {
+  // Check if client utils generation is enabled
+  if (!shouldGenerateClientUtils(nitro)) {
+    return
+  }
+
+  const placeholders = {
+    ...getDefaultPaths(nitro),
+    serviceName,
+  }
+  const clientUtilsConfig = getClientUtilsConfig(nitro)
+
+  // Resolve ofetch.ts path
+  const ofetchPath = resolveFilePath(
+    clientUtilsConfig.ofetch,
+    clientUtilsConfig.enabled,
+    true,
+    '{clientGraphql}/{serviceName}/ofetch.ts',
+    placeholders,
+  )
+
+  if (!ofetchPath) {
+    return
+  }
 
   // Create service directory if it doesn't exist
+  const serviceDir = dirname(ofetchPath)
   if (!existsSync(serviceDir)) {
     mkdirSync(serviceDir, { recursive: true })
   }
@@ -70,15 +130,43 @@ export function createGraphQLClient(endpoint: string): Requester {
 }
 
 export const $sdk = getSdk(createGraphQLClient('/api/graphql'))`
-    writeFileSync(ofetchPath, ofetchContent, 'utf-8')
+    writeFileIfNotExists(ofetchPath, ofetchContent, `${serviceName} ofetch.ts`)
   }
 }
 
-function generateExternalOfetchClient(clientDir: string, serviceName: string, endpoint: string) {
-  const serviceDir = resolve(clientDir, serviceName)
-  const ofetchPath = resolve(serviceDir, 'ofetch.ts')
+function generateExternalOfetchClient(
+  nitro: Nitro,
+  service: any, // ExternalGraphQLService
+  endpoint: string,
+) {
+  // Check if client utils generation is enabled
+  if (!shouldGenerateClientUtils(nitro)) {
+    return
+  }
+
+  const serviceName = service.name
+  const placeholders = {
+    ...getDefaultPaths(nitro),
+    serviceName,
+  }
+  const clientUtilsConfig = getClientUtilsConfig(nitro)
+
+  // Resolve ofetch.ts path with service-specific override
+  // Priority: service.paths.ofetch > global clientUtils.ofetch > default
+  const ofetchPath = resolveFilePath(
+    service.paths?.ofetch ?? clientUtilsConfig.ofetch, // Service-specific path first
+    clientUtilsConfig.enabled,
+    true,
+    '{clientGraphql}/{serviceName}/ofetch.ts',
+    placeholders,
+  )
+
+  if (!ofetchPath) {
+    return
+  }
 
   // Create service directory if it doesn't exist
+  const serviceDir = dirname(ofetchPath)
   if (!existsSync(serviceDir)) {
     mkdirSync(serviceDir, { recursive: true })
   }
@@ -109,7 +197,7 @@ export function create${capitalizedServiceName}GraphQLClient(endpoint: string = 
 }
 
 export const $${serviceName}Sdk: Sdk = getSdk(create${capitalizedServiceName}GraphQLClient())`
-    writeFileSync(ofetchPath, ofetchContent, 'utf-8')
+    writeFileIfNotExists(ofetchPath, ofetchContent, `${serviceName} external ofetch.ts`)
   }
 }
 
@@ -259,6 +347,12 @@ function validateNoDuplicateTypes(schemas: string[], schemaStrings: string[]): b
 
 export async function serverTypeGeneration(app: Nitro) {
   try {
+    // Check if type generation is enabled
+    if (!shouldGenerateTypes(app)) {
+      consola.debug('[nitro-graphql] Server type generation is disabled')
+      return
+    }
+
     const schemas = app.scanSchemas || []
 
     if (!schemas.length) {
@@ -301,9 +395,23 @@ export async function serverTypeGeneration(app: Nitro) {
     mkdirSync(dirname(schemaPath), { recursive: true })
     writeFileSync(schemaPath, printSchema, 'utf-8')
 
-    const serverTypesPath = resolve(app.options.buildDir, 'types', 'nitro-graphql-server.d.ts')
-    mkdirSync(dirname(serverTypesPath), { recursive: true })
-    writeFileSync(serverTypesPath, data, 'utf-8')
+    // Resolve server types path from config
+    const placeholders = getDefaultPaths(app)
+    const typesConfig = getTypesConfig(app)
+
+    const serverTypesPath = resolveFilePath(
+      typesConfig.server,
+      typesConfig.enabled,
+      true,
+      '{typesDir}/nitro-graphql-server.d.ts',
+      placeholders,
+    )
+
+    if (serverTypesPath) {
+      mkdirSync(dirname(serverTypesPath), { recursive: true })
+      writeFileSync(serverTypesPath, data, 'utf-8')
+      consola.success(`[nitro-graphql] Generated server types at: ${serverTypesPath}`)
+    }
   }
   catch (error) {
     consola.error('Server schema generation error:', error)
@@ -389,22 +497,48 @@ async function generateMainClientTypes(nitro: Nitro) {
     return
   }
 
-  const clientTypesPath = resolve(nitro.options.buildDir, 'types', 'nitro-graphql-client.d.ts')
-  const defaultServiceDir = resolve(nitro.graphql.clientDir, 'default')
-  const sdkTypesPath = resolve(defaultServiceDir, 'sdk.ts')
+  // Resolve client types path from config
+  const placeholders = getDefaultPaths(nitro)
+  const typesConfig = getTypesConfig(nitro)
+  const sdkConfig = getSdkConfig(nitro)
 
-  mkdirSync(dirname(clientTypesPath), { recursive: true })
-  writeFileSync(clientTypesPath, types.types, 'utf-8')
-  mkdirSync(defaultServiceDir, { recursive: true })
-  writeFileSync(sdkTypesPath, types.sdk, 'utf-8')
+  // 1. Generate client type definitions
+  const clientTypesPath = resolveFilePath(
+    typesConfig.client,
+    typesConfig.enabled,
+    true,
+    '{typesDir}/nitro-graphql-client.d.ts',
+    placeholders,
+  )
+
+  if (clientTypesPath) {
+    mkdirSync(dirname(clientTypesPath), { recursive: true })
+    writeFileSync(clientTypesPath, types.types, 'utf-8')
+    consola.success(`[nitro-graphql] Generated client types at: ${clientTypesPath}`)
+  }
+
+  // 2. Generate SDK file
+  const sdkPath = resolveFilePath(
+    sdkConfig.main,
+    sdkConfig.enabled,
+    true,
+    '{clientGraphql}/default/sdk.ts',
+    placeholders,
+  )
+
+  if (sdkPath) {
+    mkdirSync(dirname(sdkPath), { recursive: true })
+    writeFileSync(sdkPath, types.sdk, 'utf-8')
+    consola.success(`[nitro-graphql] Generated SDK at: ${sdkPath}`)
+  }
 
   // Generate ofetch client for Nuxt framework
   if (nitro.options.framework?.name === 'nuxt') {
     // Always generate default service ofetch client (only if it doesn't exist)
-    generateNuxtOfetchClient(nitro.graphql.clientDir, 'default')
+    generateNuxtOfetchClient(nitro, nitro.graphql.clientDir, 'default')
 
     const externalServices = nitro.options.graphql?.externalServices || []
-    generateGraphQLIndexFile(nitro.graphql.clientDir, externalServices)
+    generateGraphQLIndexFile(nitro, nitro.graphql.clientDir, externalServices)
   }
 }
 
@@ -450,19 +584,50 @@ async function generateExternalServicesTypes(nitro: Nitro) {
         continue
       }
 
-      // Write service-specific type files
-      const serviceTypesPath = resolve(nitro.options.buildDir, 'types', `nitro-graphql-client-${service.name}.d.ts`)
-      const serviceDir = resolve(nitro.graphql.clientDir, service.name)
-      const serviceSdkPath = resolve(serviceDir, 'sdk.ts')
+      // Resolve paths from config with service-specific overrides
+      const placeholders = {
+        ...getDefaultPaths(nitro),
+        serviceName: service.name,
+      }
+      const typesConfig = getTypesConfig(nitro)
+      const sdkConfig = getSdkConfig(nitro)
 
-      mkdirSync(dirname(serviceTypesPath), { recursive: true })
-      writeFileSync(serviceTypesPath, types.types, 'utf-8')
-      mkdirSync(serviceDir, { recursive: true })
-      writeFileSync(serviceSdkPath, types.sdk, 'utf-8')
+      // Service-specific paths take precedence over global config
+      // Priority: service.paths.X > global X.external > default
+
+      // 1. Generate external service type definitions
+      const serviceTypesPath = resolveFilePath(
+        service.paths?.types ?? typesConfig.external, // Service-specific path first
+        typesConfig.enabled,
+        true,
+        '{typesDir}/nitro-graphql-client-{serviceName}.d.ts',
+        placeholders,
+      )
+
+      if (serviceTypesPath) {
+        mkdirSync(dirname(serviceTypesPath), { recursive: true })
+        writeFileSync(serviceTypesPath, types.types, 'utf-8')
+        consola.success(`[graphql:${service.name}] Generated types at: ${serviceTypesPath}`)
+      }
+
+      // 2. Generate external service SDK
+      const serviceSdkPath = resolveFilePath(
+        service.paths?.sdk ?? sdkConfig.external, // Service-specific path first
+        sdkConfig.enabled,
+        true,
+        '{clientGraphql}/{serviceName}/sdk.ts',
+        placeholders,
+      )
+
+      if (serviceSdkPath) {
+        mkdirSync(dirname(serviceSdkPath), { recursive: true })
+        writeFileSync(serviceSdkPath, types.sdk, 'utf-8')
+        consola.success(`[graphql:${service.name}] Generated SDK at: ${serviceSdkPath}`)
+      }
 
       // Generate ofetch client for Nuxt framework
       if (nitro.options.framework?.name === 'nuxt') {
-        generateExternalOfetchClient(nitro.graphql.clientDir, service.name, service.endpoint)
+        generateExternalOfetchClient(nitro, service, service.endpoint)
       }
 
       consola.success(`[graphql:${service.name}] External service types generated successfully`)

--- a/src/utils/type-generation.ts
+++ b/src/utils/type-generation.ts
@@ -17,7 +17,6 @@ import {
   getTypesConfig,
   resolveFilePath,
   shouldGenerateClientUtils,
-  shouldGenerateSDK,
   shouldGenerateTypes,
 } from './path-resolver'
 import { generateTypes } from './server-codegen'


### PR DESCRIPTION
## 🎯 Summary

Add comprehensive control over auto-generated files with custom path support. Perfect for library development, monorepos, and custom project structures.

## ✨ Features

### 1. Fine-Grained File Control
Control each generated file individually with three options:
- `false` - Don't generate
- `true` - Generate at default location
- `string` - Generate at custom path

### 2. Configuration Categories
- **scaffold**: graphql.config.ts, schema.ts, config.ts, context.ts
- **clientUtils**: index.ts, ofetch.ts (Nuxt only)
- **sdk**: Main and external service SDKs
- **types**: Server, client, and external service types
- **paths**: Global path overrides

### 3. Service-Specific Paths ⭐ NEW
Each external service can now define custom paths that override global config:

```typescript
externalServices: [
  {
    name: 'github',
    paths: {
      sdk: 'app/graphql/organization/github-sdk.ts',
      types: 'types/github.d.ts',
      ofetch: 'app/graphql/organization/github-client.ts'
    }
  }
]
```

### 4. Path Placeholders
Support for dynamic placeholders in custom paths:
- `{serviceName}`, `{buildDir}`, `{rootDir}`, `{framework}`
- `{typesDir}`, `{serverGraphql}`, `{clientGraphql}`

### 5. Path Resolution Priority
1. Service-specific path
2. Category config
3. Global paths
4. Framework defaults

## 📝 Examples

### Library Mode
```typescript
graphql: {
  scaffold: false,        // No scaffolding
  clientUtils: false,     // No client utils
}
```

### Custom Monorepo Structure
```typescript
graphql: {
  paths: {
    serverGraphql: 'packages/api/src/graphql',
    clientGraphql: 'packages/web/src/graphql',
    typesDir: 'packages/types/src/generated',
  }
}
```

### Service Organization
```typescript
externalServices: [
  {
    name: 'github',
    paths: { sdk: 'app/graphql/vcs/github-sdk.ts' }
  },
  {
    name: 'stripe',
    paths: { sdk: 'app/graphql/billing/stripe-sdk.ts' }
  }
]
```

## 📦 Changes

### New Files
- `src/utils/path-resolver.ts` - Path resolution and placeholder system (233 lines)
- `src/utils/file-generator.ts` - File generation utilities (103 lines)

### Updated Files
- `src/types/index.ts` - New config types and interfaces (+125 lines)
- `src/index.ts` - Scaffold file generation with config control
- `src/utils/type-generation.ts` - SDK, types, client utils with config control
- `README.md` - Comprehensive documentation with examples (+240 lines)

### Statistics
- 6 files changed
- 981 insertions(+)
- 58 deletions(-)

## 🧪 Test plan

- [ ] Library mode: Verify scaffold files not generated when `scaffold: false`
- [ ] Custom paths: Test custom path generation with placeholders
- [ ] Service-specific paths: Verify external services use custom paths
- [ ] Path resolution: Test priority system (service > category > global > default)
- [ ] Backward compatibility: Ensure existing configs still work
- [ ] Nuxt vs Nitro: Test both frameworks with new config
- [ ] Playgrounds: Test in playground environments

## 🔗 Related Issues

Closes #XX (if applicable)

## 🚀 Breaking Changes

None. This is fully backward compatible. All new config options are optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)