### PR TITLE
fix: respect custom type paths in TypeScript configuration and virtual imports

### DIFF
--- a/src/ecosystem/nuxt.ts
+++ b/src/ecosystem/nuxt.ts
@@ -1,7 +1,8 @@
 import type { VueTSConfig } from '@nuxt/schema'
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { defineNuxtModule, getLayerDirectories } from '@nuxt/kit'
-import { join, resolve } from 'pathe'
+import { dirname, join, relative, resolve } from 'pathe'
+import { getDefaultPaths, getTypesConfig, resolveFilePath } from '../utils/path-resolver'
 
 export interface ModuleOptions {}
 
@@ -15,41 +16,123 @@ export default defineNuxtModule<ModuleOptions>({
   },
   setup: async (_options, nuxt) => {
     nuxt.hooks.hook('prepare:types', (options) => {
-      options.references.push({ path: 'types/nitro-graphql-client.d.ts' })
+      // Create a mock Nitro-like object for path resolution
+      const mockNitro = {
+        options: {
+          rootDir: nuxt.options.rootDir,
+          buildDir: nuxt.options.buildDir,
+          framework: { name: 'nuxt' as const },
+          graphql: nuxt.options.nitro?.graphql,
+        },
+      } as any
 
-      options.tsConfig ??= {} as VueTSConfig
-      options.tsConfig.compilerOptions ??= {}
-      options.tsConfig.compilerOptions.paths ??= {}
-      options.tsConfig.compilerOptions.paths['#graphql/client'] = [
-        './types/nitro-graphql-client.d.ts',
-      ]
+      const placeholders = getDefaultPaths(mockNitro)
+      const typesConfig = getTypesConfig(mockNitro)
+      const tsconfigDir = dirname(join(nuxt.options.buildDir, 'tsconfig.json'))
 
-      // Add external services types
-      const externalServices = nuxt.options.nitro?.graphql?.externalServices || []
-      for (const service of externalServices) {
-        options.references.push({ path: `types/nitro-graphql-client-${service.name}.d.ts` })
-        options.tsConfig.compilerOptions.paths[`#graphql/client/${service.name}`] = [
-          `./types/nitro-graphql-client-${service.name}.d.ts`,
-        ]
+      // Helper function to convert absolute path to relative with dot
+      const relativeWithDot = (from: string, to: string): string => {
+        const rel = relative(from, to)
+        return rel.startsWith('.') ? rel : `./${rel}`
       }
 
-      options.tsConfig.include = options.tsConfig.include || []
-      options.tsConfig.include.push('./types/nitro-graphql-client.d.ts')
+      // Resolve client types path
+      const clientTypesPath = resolveFilePath(
+        typesConfig.client,
+        typesConfig.enabled,
+        true,
+        '{typesDir}/nitro-graphql-client.d.ts',
+        placeholders,
+      )
 
-      // Add external service type files to include
+      if (clientTypesPath) {
+        const relativePath = relativeWithDot(tsconfigDir, clientTypesPath)
+        options.references.push({ path: relativePath })
+
+        options.tsConfig ??= {} as VueTSConfig
+        options.tsConfig.compilerOptions ??= {}
+        options.tsConfig.compilerOptions.paths ??= {}
+        options.tsConfig.compilerOptions.paths['#graphql/client'] = [relativePath]
+
+        options.tsConfig.include = options.tsConfig.include || []
+        options.tsConfig.include.push(relativePath)
+      }
+
+      // Add external services types with proper path resolution
+      const externalServices = nuxt.options.nitro?.graphql?.externalServices || []
       for (const service of externalServices) {
-        options.tsConfig.include.push(`./types/nitro-graphql-client-${service.name}.d.ts`)
+        const servicePlaceholders = {
+          ...placeholders,
+          serviceName: service.name,
+        }
+
+        // Resolve external service types path with service-specific override
+        const externalTypesPath = resolveFilePath(
+          service.paths?.types ?? typesConfig.external,
+          typesConfig.enabled,
+          true,
+          '{typesDir}/nitro-graphql-client-{serviceName}.d.ts',
+          servicePlaceholders,
+        )
+
+        if (externalTypesPath) {
+          const relativePath = relativeWithDot(tsconfigDir, externalTypesPath)
+          options.references.push({ path: relativePath })
+          options.tsConfig.compilerOptions.paths[`#graphql/client/${service.name}`] = [relativePath]
+          options.tsConfig.include.push(relativePath)
+        }
       }
     })
 
     // Add Vite/webpack alias for runtime resolution
+    // Note: Aliases are resolved during prepare:types hook above using path-resolver
+    // These are fallback aliases for runtime module resolution
     nuxt.options.alias = nuxt.options.alias || {}
-    nuxt.options.alias['#graphql/client'] = join(nuxt.options.buildDir, 'types/nitro-graphql-client.d.ts')
 
-    // Add aliases for external services
+    // Create mock Nitro for path resolution in alias setup
+    const mockNitro = {
+      options: {
+        rootDir: nuxt.options.rootDir,
+        buildDir: nuxt.options.buildDir,
+        framework: { name: 'nuxt' as const },
+        graphql: nuxt.options.nitro?.graphql,
+      },
+    } as any
+
+    const placeholders = getDefaultPaths(mockNitro)
+    const typesConfig = getTypesConfig(mockNitro)
+
+    // Resolve client types path for alias
+    const clientTypesPath = resolveFilePath(
+      typesConfig.client,
+      typesConfig.enabled,
+      true,
+      '{typesDir}/nitro-graphql-client.d.ts',
+      placeholders,
+    )
+    if (clientTypesPath) {
+      nuxt.options.alias['#graphql/client'] = clientTypesPath
+    }
+
+    // Add aliases for external services with proper path resolution
     const externalServices = nuxt.options.nitro?.graphql?.externalServices || []
     for (const service of externalServices) {
-      nuxt.options.alias[`#graphql/client/${service.name}`] = join(nuxt.options.buildDir, `types/nitro-graphql-client-${service.name}.d.ts`)
+      const servicePlaceholders = {
+        ...placeholders,
+        serviceName: service.name,
+      }
+
+      const externalTypesPath = resolveFilePath(
+        service.paths?.types ?? typesConfig.external,
+        typesConfig.enabled,
+        true,
+        '{typesDir}/nitro-graphql-client-{serviceName}.d.ts',
+        servicePlaceholders,
+      )
+
+      if (externalTypesPath) {
+        nuxt.options.alias[`#graphql/client/${service.name}`] = externalTypesPath
+      }
     }
 
     nuxt.hook('imports:dirs', (dirs) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { writeFileIfNotExists } from './utils/file-generator'
 import {
   getDefaultPaths,
   getScaffoldConfig,
+  getTypesConfig,
   resolveFilePath,
   shouldGenerateScaffold,
 } from './utils/path-resolver'
@@ -179,7 +180,6 @@ export default defineNitroModule({
       nitro.options.typescript.tsconfigPath,
     )
     const tsconfigDir = dirname(tsConfigPath)
-    const typesDir = resolve(nitro.options.buildDir, 'types')
 
     const schemas = await scanSchemas(nitro)
     nitro.scanSchemas = schemas
@@ -397,12 +397,40 @@ export default defineNitroModule({
       types.tsConfig ||= {}
       types.tsConfig.compilerOptions ??= {}
       types.tsConfig.compilerOptions.paths ??= {}
-      types.tsConfig.compilerOptions.paths['#graphql/server'] = [
-        relativeWithDot(tsconfigDir, join(typesDir, 'nitro-graphql-server.d.ts')),
-      ]
-      types.tsConfig.compilerOptions.paths['#graphql/client'] = [
-        relativeWithDot(tsconfigDir, join(typesDir, 'nitro-graphql-client.d.ts')),
-      ]
+
+      // Resolve paths using the same logic as type generation
+      const placeholders = getDefaultPaths(nitro)
+      const typesConfig = getTypesConfig(nitro)
+
+      // Resolve server types path
+      const serverTypesPath = resolveFilePath(
+        typesConfig.server,
+        typesConfig.enabled,
+        true,
+        '{typesDir}/nitro-graphql-server.d.ts',
+        placeholders,
+      )
+      if (serverTypesPath) {
+        types.tsConfig.compilerOptions.paths['#graphql/server'] = [
+          relativeWithDot(tsconfigDir, serverTypesPath),
+        ]
+      }
+
+      // Resolve client types path
+      const clientTypesPath = resolveFilePath(
+        typesConfig.client,
+        typesConfig.enabled,
+        true,
+        '{typesDir}/nitro-graphql-client.d.ts',
+        placeholders,
+      )
+      if (clientTypesPath) {
+        types.tsConfig.compilerOptions.paths['#graphql/client'] = [
+          relativeWithDot(tsconfigDir, clientTypesPath),
+        ]
+      }
+
+      // Schema path (always uses serverDir)
       types.tsConfig.compilerOptions.paths['#graphql/schema'] = [
         relativeWithDot(tsconfigDir, join(nitro.graphql.serverDir, 'schema.ts')),
       ]
@@ -410,25 +438,61 @@ export default defineNitroModule({
       // Add path mappings for external services
       if (nitro.options.graphql?.externalServices?.length) {
         for (const service of nitro.options.graphql.externalServices) {
-          types.tsConfig.compilerOptions.paths[`#graphql/client/${service.name}`] = [
-            relativeWithDot(tsconfigDir, join(typesDir, `nitro-graphql-client-${service.name}.d.ts`)),
-          ]
+          const servicePlaceholders = {
+            ...placeholders,
+            serviceName: service.name,
+          }
+
+          // Resolve external service types path with service-specific override
+          const externalTypesPath = resolveFilePath(
+            service.paths?.types ?? typesConfig.external,
+            typesConfig.enabled,
+            true,
+            '{typesDir}/nitro-graphql-client-{serviceName}.d.ts',
+            servicePlaceholders,
+          )
+
+          if (externalTypesPath) {
+            types.tsConfig.compilerOptions.paths[`#graphql/client/${service.name}`] = [
+              relativeWithDot(tsconfigDir, externalTypesPath),
+            ]
+          }
         }
       }
 
       types.tsConfig.include = types.tsConfig.include || []
+
+      // Add resolved type files to include
+      if (serverTypesPath) {
+        types.tsConfig.include.push(relativeWithDot(tsconfigDir, serverTypesPath))
+      }
+      if (clientTypesPath) {
+        types.tsConfig.include.push(relativeWithDot(tsconfigDir, clientTypesPath))
+      }
+      // Always include graphql.d.ts from default location
       types.tsConfig.include.push(
-        relativeWithDot(tsconfigDir, join(typesDir, 'nitro-graphql-server.d.ts')),
-        relativeWithDot(tsconfigDir, join(typesDir, 'nitro-graphql-client.d.ts')),
-        relativeWithDot(tsconfigDir, join(typesDir, 'graphql.d.ts')),
+        relativeWithDot(tsconfigDir, join(placeholders.typesDir, 'graphql.d.ts')),
       )
 
       // Add external service type files to include
       if (nitro.options.graphql?.externalServices?.length) {
         for (const service of nitro.options.graphql.externalServices) {
-          types.tsConfig.include.push(
-            relativeWithDot(tsconfigDir, join(typesDir, `nitro-graphql-client-${service.name}.d.ts`)),
+          const servicePlaceholders = {
+            ...placeholders,
+            serviceName: service.name,
+          }
+
+          const externalTypesPath = resolveFilePath(
+            service.paths?.types ?? typesConfig.external,
+            typesConfig.enabled,
+            true,
+            '{typesDir}/nitro-graphql-client-{serviceName}.d.ts',
+            servicePlaceholders,
           )
+
+          if (externalTypesPath) {
+            types.tsConfig.include.push(relativeWithDot(tsconfigDir, externalTypesPath))
+          }
         }
       }
     })

--- a/src/utils/client-codegen.ts
+++ b/src/utils/client-codegen.ts
@@ -299,6 +299,7 @@ export async function generateClientTypes(
   sdkConfig: GenericSdkConfig = {},
   outputPath?: string,
   serviceName?: string,
+  virtualTypesPath?: string,
 ) {
   // For external services, allow schema-only generation (no documents required)
   if (docs.length === 0 && !serviceName) {
@@ -405,7 +406,8 @@ export function getSdk(requester: Requester): Sdk {
       },
     })
 
-    const typesPath = serviceName ? `#graphql/client/${serviceName}` : '#graphql/client'
+    // Use provided virtual import path, or fall back to default convention
+    const typesPath = virtualTypesPath || (serviceName ? `#graphql/client/${serviceName}` : '#graphql/client')
     const sdkOutput = await preset.buildGeneratesSection({
       baseOutputDir: outputPath || 'client-types.generated.ts',
       schema: parse(printSchemaWithDirectives(schema)),
@@ -452,9 +454,10 @@ export async function generateExternalClientTypes(
   service: ExternalGraphQLService,
   schema: GraphQLSchema,
   docs: Source[],
+  virtualTypesPath?: string,
 ): Promise<{ types: string, sdk: string } | false> {
   const config = service.codegen?.client || {}
   const sdkConfig = service.codegen?.clientSDK || {}
 
-  return generateClientTypes(schema, docs, config, sdkConfig, undefined, service.name)
+  return generateClientTypes(schema, docs, config, sdkConfig, undefined, service.name, virtualTypesPath)
 }

--- a/src/utils/path-resolver.ts
+++ b/src/utils/path-resolver.ts
@@ -6,7 +6,7 @@ import type {
   SdkConfig,
   TypesConfig,
 } from '../types'
-import { resolve } from 'pathe'
+import { isAbsolute, resolve } from 'pathe'
 
 /**
  * Placeholder values for path resolution
@@ -107,8 +107,8 @@ export function resolveFilePath(
   // If config is a custom path, use it
   if (typeof config === 'string') {
     const customPath = replacePlaceholders(config, placeholders)
-    // Make it absolute if it's relative
-    return resolve(placeholders.rootDir, customPath)
+    // If already absolute, use as-is; if relative, resolve against rootDir
+    return isAbsolute(customPath) ? customPath : resolve(placeholders.rootDir, customPath)
   }
 
   // Use default path with placeholder support


### PR DESCRIPTION
## Summary

- Fixed TypeScript path mappings to properly respect custom path configurations from v2.0
- Improved consistency between type generation paths and virtual import paths
- Added support for service-specific type path overrides

## Changes

### TypeScript Configuration (`src/index.ts`)
- Updated path mappings to use `getTypesConfig()` and `resolveFilePath()` utilities instead of hardcoded paths
- Added conditional path registration (only adds paths if files are actually generated)
- Fixed external service type paths to respect service-specific `paths.types` overrides
- Ensured `tsconfig.include` paths match actual generated file locations

### Client Code Generation (`src/utils/client-codegen.ts`)
- Added optional `virtualTypesPath` parameter to `generateClientTypes()` function
- Updated `generateExternalClientTypes()` to pass through custom virtual import paths
- Allows customization of virtual import paths like `#graphql/client/{serviceName}`

## Problem Solved

When users configured custom type paths using the new path configuration system (introduced in v2.0), the TypeScript path mappings were still using hardcoded default paths. This caused:
- Import errors when types were generated to custom locations
- TypeScript not finding the generated type files
- Inconsistency between configured paths and actual virtual imports

## Test Plan

- [ ] Test with default configuration (no custom paths)
- [ ] Test with custom `types.server` path
- [ ] Test with custom `types.client` path  
- [ ] Test with external services using custom `service.paths.types`
- [ ] Verify `#graphql/server` and `#graphql/client` imports work correctly
- [ ] Check tsconfig includes the correct files

🤖 Generated with [Claude Code](https://claude.com/claude-code)