### PR TITLE
feat: add .gql file extension support for schema and document scanning

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -56,9 +56,9 @@ export const DIRECTIVE_EXTENSIONS = ['.directive.ts', '.directive.js'] as const
 export const GLOB_SCAN_PATTERN = '**/*.{graphql,gql,js,mjs,cjs,ts,mts,cts,tsx,jsx}' as const
 
 /**
- * GraphQL file pattern for glob
+ * GraphQL file pattern for glob (supports both .graphql and .gql extensions)
  */
-export const GRAPHQL_GLOB_PATTERN = '**/*.graphql' as const
+export const GRAPHQL_GLOB_PATTERN = '**/*.{graphql,gql}' as const
 
 /**
  * Resolver file pattern for glob

--- a/src/core/scanning/documents.ts
+++ b/src/core/scanning/documents.ts
@@ -20,7 +20,7 @@ export interface ScanDocumentsOptions {
 }
 
 /**
- * Scan for GraphQL client documents (.graphql) in client directory
+ * Scan for GraphQL client documents (.graphql, .gql) in client directory
  * Excludes files from external service directories
  */
 export async function scanDocumentsCore(

--- a/src/core/scanning/schemas.ts
+++ b/src/core/scanning/schemas.ts
@@ -9,7 +9,7 @@ import { GRAPHQL_GLOB_PATTERN } from '../constants'
 import { extractPaths, scanWithLayers } from './common'
 
 /**
- * Scan for GraphQL schema files (.graphql) in server directory
+ * Scan for GraphQL schema files (.graphql, .gql) in server directory
  */
 export async function scanSchemasCore(ctx: ScanContext): Promise<ScanResult<string>> {
   const warnings: string[] = []

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -4,12 +4,17 @@ import {
   FRAMEWORK_NITRO,
   FRAMEWORK_NUXT,
   GRAPHQL_EXTENSIONS,
+  GRAPHQL_GLOB_PATTERN,
   RESOLVER_EXTENSIONS,
 } from '../../src/core/constants'
 
 describe('constants', () => {
   it('should export GraphQL extensions', () => {
     expect(GRAPHQL_EXTENSIONS).toEqual(['.graphql', '.gql'])
+  })
+
+  it('should export GraphQL glob pattern with both extensions', () => {
+    expect(GRAPHQL_GLOB_PATTERN).toBe('**/*.{graphql,gql}')
   })
 
   it('should export resolver extensions', () => {

--- a/tests/unit/scanning/documents.test.ts
+++ b/tests/unit/scanning/documents.test.ts
@@ -3,7 +3,7 @@ import type { ScanContext } from '../../../src/core/types/scanning'
  * Unit tests for document scanning module
  *
  * Tests the scanDocumentsCore function which:
- * - Scans for GraphQL client documents (.graphql) in client directory
+ * - Scans for GraphQL client documents (.graphql, .gql) in client directory
  * - Filters out external service directories
  * - Supports Nuxt layers for multi-layer scanning
  */
@@ -60,6 +60,32 @@ describe('scanDocumentsCore', () => {
       expect(result.items).toHaveLength(2)
       expect(result.warnings).toHaveLength(0)
       expect(result.errors).toHaveLength(0)
+    })
+
+    it('should scan for both .graphql and .gql files in client directory', async () => {
+      mockGlob.mockResolvedValue([
+        '/project/app/graphql/queries/getUser.graphql',
+        '/project/app/graphql/mutations/createUser.gql',
+        '/project/app/graphql/fragments/userFields.gql',
+      ])
+
+      const result = await scanDocumentsCore(mockContext)
+
+      expect(result.items).toHaveLength(3)
+      expect(result.items).toContain('/project/app/graphql/queries/getUser.graphql')
+      expect(result.items).toContain('/project/app/graphql/mutations/createUser.gql')
+      expect(result.items).toContain('/project/app/graphql/fragments/userFields.gql')
+    })
+
+    it('should call glob with correct pattern for both extensions', async () => {
+      mockGlob.mockResolvedValue([])
+
+      await scanDocumentsCore(mockContext)
+
+      expect(mockGlob).toHaveBeenCalledWith(
+        expect.stringMatching(/\*\*\/\*\.\{graphql,gql\}/),
+        expect.any(Object),
+      )
     })
 
     it('should return empty array when no documents found', async () => {

--- a/tests/unit/scanning/schemas.test.ts
+++ b/tests/unit/scanning/schemas.test.ts
@@ -3,7 +3,7 @@ import type { ScanContext } from '../../../src/core/types/scanning'
  * Unit tests for schema scanning module
  *
  * Tests the scanSchemasCore and scanGraphqlCore functions which:
- * - Scan for GraphQL schema files (.graphql) in server directory
+ * - Scan for GraphQL schema files (.graphql, .gql) in server directory
  * - Support Nuxt layers for multi-layer scanning
  * - Return file paths with warnings/errors
  */
@@ -58,6 +58,21 @@ describe('scanSchemasCore', () => {
       expect(result.errors).toHaveLength(0)
     })
 
+    it('should scan for both .graphql and .gql files in server directory', async () => {
+      mockGlob.mockResolvedValue([
+        '/project/server/graphql/schema.graphql',
+        '/project/server/graphql/types.gql',
+        '/project/server/graphql/queries.gql',
+      ])
+
+      const result = await scanSchemasCore(mockContext)
+
+      expect(result.items).toHaveLength(3)
+      expect(result.items).toContain('/project/server/graphql/schema.graphql')
+      expect(result.items).toContain('/project/server/graphql/types.gql')
+      expect(result.items).toContain('/project/server/graphql/queries.gql')
+    })
+
     it('should return empty array when no files found', async () => {
       mockGlob.mockResolvedValue([])
 
@@ -68,13 +83,13 @@ describe('scanSchemasCore', () => {
       expect(result.errors).toHaveLength(0)
     })
 
-    it('should call glob with correct pattern', async () => {
+    it('should call glob with correct pattern for both extensions', async () => {
       mockGlob.mockResolvedValue([])
 
       await scanSchemasCore(mockContext)
 
       expect(mockGlob).toHaveBeenCalledWith(
-        expect.stringContaining('**/*.graphql'),
+        expect.stringMatching(/\*\*\/\*\.\{graphql,gql\}/),
         expect.objectContaining({
           cwd: '/project',
           dot: true,


### PR DESCRIPTION
## Summary

- Adds support for `.gql` file extension alongside `.graphql` for schema and document scanning
- Updates `GRAPHQL_GLOB_PATTERN` constant from `**/*.graphql` to `**/*.{graphql,gql}`
- Adds comprehensive tests for the new functionality

Closes #44

## Changes

| File | Change |
|------|--------|
| `src/core/constants.ts` | Updated `GRAPHQL_GLOB_PATTERN` to include `.gql` |
| `src/core/scanning/schemas.ts` | Updated JSDoc comment |
| `src/core/scanning/documents.ts` | Updated JSDoc comment |
| `tests/unit/constants.test.ts` | Added test for glob pattern |
| `tests/unit/scanning/schemas.test.ts` | Added tests for `.gql` scanning |
| `tests/unit/scanning/documents.test.ts` | Added tests for `.gql` scanning |

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Type check passes (`pnpm test:types`)
- [x] All 694 tests pass (`pnpm test:run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)